### PR TITLE
ci: Fix Firebase deployment workflows

### DIFF
--- a/.github/workflows/deploy-cloud-storage-rules.yml
+++ b/.github/workflows/deploy-cloud-storage-rules.yml
@@ -1,27 +1,40 @@
-name: Deploy to Firebase Hosting on merge
+name: "Deploy Storage Rules (develop)"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      # Triggers ONLY on this file
+      - "storage.rules"
+      - ".github/workflows/deploy-storage-rules.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build_and_deploy:
+  deploy_storage_rules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
-          REACT_APP_FIREBASE_API_KEY: ${{secrets.REACT_APP_FIREBASE_API_KEY}}
-          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{secrets.REACT_APP_FIREBASE_AUTH_DOMAIN}}
-          REACT_APP_FIREBASE_PROJECT_ID: ${{secrets.REACT_APP_FIREBASE_PROJECT_ID}}
-          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{secrets.REACT_APP_FIREBASE_STORAGE_BUCKET}}
-          REACT_APP_FIREBASE_MESSAGE_SENDER_ID: ${{secrets.REACT_APP_FIREBASE_MESSAGE_SENDER_ID}}
-          REACT_APP_FIREBASE_APP_ID: ${{secrets.REACT_APP_FIREBASE_APP_ID}}
-          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{secrets.REACT_APP_FIREBASE_MEASUREMENT_ID}}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_MULTIUSER_LABORATORY_WEBSITE }}"
-          channelId: develop
-          projectId: multiuser-laboratory-website
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase Rules
+        # Note the '--only storage:rules'
+        run: firebase deploy --only storage:rules --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}

--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -1,27 +1,40 @@
-name: Deploy to Firebase Hosting on merge
+name: "Deploy Firestore Rules (develop)"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    paths:
+      # Triggers ONLY on this file
+      - "firestore.rules"
+      - ".github/workflows/deploy-firestore-rules.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build_and_deploy:
+  deploy_firestore_rules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
-          REACT_APP_FIREBASE_API_KEY: ${{secrets.REACT_APP_FIREBASE_API_KEY}}
-          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{secrets.REACT_APP_FIREBASE_AUTH_DOMAIN}}
-          REACT_APP_FIREBASE_PROJECT_ID: ${{secrets.REACT_APP_FIREBASE_PROJECT_ID}}
-          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{secrets.REACT_APP_FIREBASE_STORAGE_BUCKET}}
-          REACT_APP_FIREBASE_MESSAGE_SENDER_ID: ${{secrets.REACT_APP_FIREBASE_MESSAGE_SENDER_ID}}
-          REACT_APP_FIREBASE_APP_ID: ${{secrets.REACT_APP_FIREBASE_APP_ID}}
-          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{secrets.REACT_APP_FIREBASE_MEASUREMENT_ID}}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_MULTIUSER_LABORATORY_WEBSITE }}"
-          channelId: develop
-          projectId: multiuser-laboratory-website
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase Rules
+        # Note the '--only firestore:rules'
+        run: firebase deploy --only firestore:rules --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -4,8 +4,8 @@ name: Deploy to Firebase Functions
     branches:
       - develop
     paths:
-      - 'functions/**'
-      - '.github/workflows/deploy-functions.yml'
+      - "functions/**"
+      - ".github/workflows/deploy-functions.yml"
 permissions:
   contents: read
   id-token: write
@@ -17,12 +17,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       # Authenticate using Workload Identity (recommended)
       - name: Authenticate to Google Cloud
         id: google_auth
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
         with:
@@ -39,4 +39,4 @@ jobs:
       - name: Deploy to Firebase Functions
         run: firebase deploy --only functions --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}

--- a/.github/workflows/release-cloud-storage-rules.yml
+++ b/.github/workflows/release-cloud-storage-rules.yml
@@ -1,27 +1,35 @@
-name: Deploy to Firebase Hosting on merge
+name: "Release Storage Rules (main)"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "storage.rules"
+      - ".github/workflows/release-storage-rules.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build_and_deploy:
+  release_storage_rules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
-          REACT_APP_FIREBASE_API_KEY: ${{secrets.REACT_APP_FIREBASE_API_KEY}}
-          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{secrets.REACT_APP_FIREBASE_AUTH_DOMAIN}}
-          REACT_APP_FIREBASE_PROJECT_ID: ${{secrets.REACT_APP_FIREBASE_PROJECT_ID}}
-          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{secrets.REACT_APP_FIREBASE_STORAGE_BUCKET}}
-          REACT_APP_FIREBASE_MESSAGE_SENDER_ID: ${{secrets.REACT_APP_FIREBASE_MESSAGE_SENDER_ID}}
-          REACT_APP_FIREBASE_APP_ID: ${{secrets.REACT_APP_FIREBASE_APP_ID}}
-          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{secrets.REACT_APP_FIREBASE_MEASUREMENT_ID}}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_MULTIUSER_LABORATORY_WEBSITE }}"
-          channelId: live
-          projectId: multiuser-laboratory-website
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Deploy to Firebase Rules
+        run: firebase deploy --only storage:rules --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}

--- a/.github/workflows/release-firestore-rules.yml
+++ b/.github/workflows/release-firestore-rules.yml
@@ -1,27 +1,35 @@
-name: Deploy to Firebase Hosting on merge
+name: "Release Firestore Rules (main)"
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "firestore.rules"
+      - ".github/workflows/release-firestore-rules.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build_and_deploy:
+  release_firestore_rules:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
-          REACT_APP_FIREBASE_API_KEY: ${{secrets.REACT_APP_FIREBASE_API_KEY}}
-          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{secrets.REACT_APP_FIREBASE_AUTH_DOMAIN}}
-          REACT_APP_FIREBASE_PROJECT_ID: ${{secrets.REACT_APP_FIREBASE_PROJECT_ID}}
-          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{secrets.REACT_APP_FIREBASE_STORAGE_BUCKET}}
-          REACT_APP_FIREBASE_MESSAGE_SENDER_ID: ${{secrets.REACT_APP_FIREBASE_MESSAGE_SENDER_ID}}
-          REACT_APP_FIREBASE_APP_ID: ${{secrets.REACT_APP_FIREBASE_APP_ID}}
-          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{secrets.REACT_APP_FIREBASE_MEASUREMENT_ID}}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_MULTIUSER_LABORATORY_WEBSITE }}"
-          channelId: live
-          projectId: multiuser-laboratory-website
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Deploy to Firebase Rules
+        run: firebase deploy --only firestore:rules --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}

--- a/.github/workflows/release-functions.yml
+++ b/.github/workflows/release-functions.yml
@@ -1,29 +1,38 @@
-name: Deploy to Firebase Hosting on merge
-"on":
+name: "Release Functions (main)"
+on:
   push:
     branches:
-      - main
+      - main # <-- Triggers on main
+    paths:
+      - "functions/**"
+      - ".github/workflows/release-functions.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build_and_deploy:
+  deploy_functions:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Build
-        run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: "google-github-actions/auth@v2"
         env:
           CI: false
-          REACT_APP_FIREBASE_API_KEY: ${{secrets.REACT_APP_FIREBASE_API_KEY}}
-          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{secrets.REACT_APP_FIREBASE_AUTH_DOMAIN}}
-          REACT_APP_FIREBASE_PROJECT_ID: ${{secrets.REACT_APP_FIREBASE_PROJECT_ID}}
-          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{secrets.REACT_APP_FIREBASE_STORAGE_BUCKET}}
-          REACT_APP_FIREBASE_MESSAGE_SENDER_ID: ${{secrets.REACT_APP_FIREBASE_MESSAGE_SENDER_ID}}
-          REACT_APP_FIREBASE_APP_ID: ${{secrets.REACT_APP_FIREBASE_APP_ID}}
-          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{secrets.REACT_APP_FIREBASE_MEASUREMENT_ID}}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_MULTIUSER_LABORATORY_WEBSITE }}"
-          channelId: live
-          projectId: multiuser-laboratory-website
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Install Function Dependencies
+        run: npm ci
+        working-directory: ./functions
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Deploy to Firebase Functions
+        run: firebase deploy --only functions --project ${{ secrets.GCP_PROJECT_ID }} --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google_auth.outputs.credentials_file_path }}


### PR DESCRIPTION
This commit corrects several critical bugs in the Firebase deployment pipelines:

* Fixes all rules workflows (e.g., `deploy-firestore-rules`) which were incorrectly deploying Hosting instead of rules.
* Fixes `release-functions.yml` which was also incorrectly deploying Hosting instead of Cloud Functions.
* Fixes a typo in `deploy-functions.yml` referencing `steps.auth` instead of the correct `steps.google_auth` ID.

All workflows are now standardized to use Workload Identity and deploy the correct Firebase product.

Fixes #27