### PR TITLE
Disable user type editing

### DIFF
--- a/src/components/UserForm/index.tsx
+++ b/src/components/UserForm/index.tsx
@@ -33,7 +33,9 @@ type rolesMap = { [key: string]: roleType };
 const personsData: rolesMap = {
   individual: { displayName: { pt: "Pessoa Física", en: "Individual" } },
   company: { displayName: { pt: "Pessoa Jurídica", en: "Company" } },
-  student: { displayName: { pt: "Estudante", en: "Student" } },
+  student: {
+    displayName: { pt: "Estudante (UNICAMP)", en: "Student (UNICAMP)" },
+  },
 };
 
 // const rolesDataTest: rolesMap = {
@@ -338,9 +340,13 @@ const UserForm = () => {
             />
           </Form.Group>
         </Row>
+
+        {/*
         <Form.Text className="mb-3">Contato:</Form.Text>
         <Row className="mb-3">
-          {/* Email */}
+          {
+          //Email
+          }
           <Form.Group as={Col} md="6" controlId="validationCustom03">
             <Form.Label>Email</Form.Label>
             <Form.Control
@@ -354,7 +360,9 @@ const UserForm = () => {
               value={targetUser.email || ""}
             />
           </Form.Group>
-          {/* Phone Number */}
+          { 
+          //Phone Number
+          }
           <Form.Group as={Col} md="6" controlId="validationCustomUsername">
             <Form.Label>Celular</Form.Label>
             <IMaskInput
@@ -375,6 +383,7 @@ const UserForm = () => {
             />
           </Form.Group>
         </Row>
+        */}
         <Form.Text className="mb-3">Conta:</Form.Text>
         <Row className="mb-3">
           {/* Person Type */}
@@ -469,11 +478,12 @@ const UserForm = () => {
           <Form.Group as={Col} md="6" controlId="">
             <Form.Label>Tipo</Form.Label>
             <Form.Select
-              disabled={callerRole !== "admin"}
               required
               name="role"
               value={targetUser.role}
               onChange={(event) => handleInputChange(event, "role")}
+              // disabled={callerRole !== "admin"}
+              disabled
             >
               <option value="" disabled>
                 Selecione


### PR DESCRIPTION
Disabled user type editing until the set of user types is well stablished in upcoming meetings. This way we avoid poluting the database with wrong data, avoiding future rework.